### PR TITLE
Small change to allow overriding the RETURNTRANSFER curlopt.

### DIFF
--- a/parallelcurl.php
+++ b/parallelcurl.php
@@ -75,9 +75,9 @@ class ParallelCurl {
 	        $this->waitForOutstandingRequestsToDropBelow($this->max_requests);
     
         $ch = curl_init();
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
         curl_setopt_array($ch, $this->options);
         curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
 
         if (isset($post_fields)) {
             curl_setopt($ch, CURLOPT_POST, TRUE);


### PR DESCRIPTION
All the other curlopts used (ie: URL, POST) are directly implied by the
function input parameters, but RETURNTRANSFER is not and is more of a
default.

This commit makes it possible to override the RETURNTRANSFER default
via the curlopt array passed at construction.
