### PR TITLE
Performance enhancements by reusing curl handlers + fixing bug of potential queue blocking

### DIFF
--- a/parallelcurl.php
+++ b/parallelcurl.php
@@ -133,10 +133,10 @@ class ParallelCurl {
             $callback = $request['callback'];
             $user_data = $request['user_data'];
             
-            call_user_func($callback, $content, $url, $ch, $user_data);
-            
             unset($this->outstanding_requests[$ch_array_key]);
-            
+
+            call_user_func($callback, $content, $url, $ch, $user_data);
+                        
             curl_multi_remove_handle($this->multi_handle, $ch);
         }
     


### PR DESCRIPTION
1. Reusing curl handlers by storing them in a pool so that they are reused with subsequent requests.
2. Fixing a bug of queue blocking when callbacks initiate new requests.

Thanks
