### PR TITLE
clear outstanding request before invoking callback

### DIFF
--- a/parallelcurl.php
+++ b/parallelcurl.php
@@ -148,9 +148,9 @@ class ParallelCurl {
             $callback = $request['callback'];
             $user_data = $request['user_data'];
             
-            call_user_func($callback, $content, $url, $ch, $user_data);
-            
             unset($this->outstanding_requests[$ch_array_key]);
+            
+            call_user_func($callback, $content, $url, $ch, $user_data);
             
             curl_multi_remove_handle($this->multi_handle, $ch);
         }


### PR DESCRIPTION
When you put new requests into queue by calling "startRequest" **inside** a callback, the outstanding request never gets a chance to be cleaned up from queue and the program gets stuck. Demonstrated by this simple script:

``` php
<?
require 'parallelcurl.php';
$pc = new ParallelCurl(5);

$callback = function($content, $url, $ch, $userParams) use (&$callback, $pc) {
  // Print status of finished request
  $i = $userParams['i'];
  $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);    
  echo "Request index {$i}, got http code: $httpcode\n";

  if ($i == 20) {
    // That's enough
    echo "Finished!\n";
    return;
  }

  // Continue with next request
  // This is a common usecase when next request url depends on contents of current page
  $pc->startRequest('example.com', $callback, ['i' => $i + 1]);
};

$pc->startRequest('example.com', $callback, ['i' => 1]);
$pc->finishAllRequests(); 
```

Try running it without patch (script gets stuck after 5 requests) and with patch (script correctly performs 20 requests).
The proposed change fixes it by first removing outstanding request from the queue and then invoking the callback.
